### PR TITLE
LUGG-654 - Add read more settings

### DIFF
--- a/luggage_projects.info
+++ b/luggage_projects.info
@@ -58,5 +58,6 @@ features[variable][] = node_preview_project
 features[variable][] = node_submitted_project
 features[variable][] = pathauto_node_project_pattern
 features[variable][] = publishcontent_project
+features[variable][] = read_more_project_view_modes
 features[views_view][] = projects
 github = https://raw.github.com/isubit/luggage_projects/master/luggage_projects.info

--- a/luggage_projects.strongarm.inc
+++ b/luggage_projects.strongarm.inc
@@ -115,5 +115,21 @@ function luggage_projects_strongarm() {
   $strongarm->value = 1;
   $export['publishcontent_project'] = $strongarm;
 
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'read_more_project_view_modes';
+  $strongarm->value = array(
+    'teaser' => 'teaser',
+    'search_result' => 'search_result',
+    'full' => 0,
+    'rss' => 0,
+    'search_index' => 0,
+    'diff_standard' => 0,
+    'token' => 0,
+    'revision' => 0,
+  );
+  $export['read_more_project_view_modes'] = $strongarm;
+  
   return $export;
 }


### PR DESCRIPTION
Added strongarm settings for the read more module.

To test:
Pull down these changes on a site with an updated version of the read more module
Run "drush fra -y" on the site you're using for testing
Go to Administration > Configuration > Content Authoring > Read More link
Scroll down to the "Content Types" section of configuration
Verify that teaser and search result highlighting input boxes are both checked for project
