### PR TITLE
LUGG-529 Consistency in Content Types

### DIFF
--- a/luggage_projects.features.field_instance.inc
+++ b/luggage_projects.features.field_instance.inc
@@ -451,7 +451,7 @@ function luggage_projects_field_default_field_instances() {
         'year_range' => '-3:+3',
       ),
       'type' => 'date_text',
-      'weight' => 15,
+      'weight' => 12,
     ),
   );
 
@@ -732,7 +732,7 @@ function luggage_projects_field_default_field_instances() {
       'module' => 'number',
       'settings' => array(),
       'type' => 'number',
-      'weight' => 16,
+      'weight' => 13,
     ),
   );
 

--- a/luggage_projects.features.field_instance.inc
+++ b/luggage_projects.features.field_instance.inc
@@ -123,7 +123,7 @@ function luggage_projects_field_default_field_instances() {
     'entity_type' => 'node',
     'field_name' => 'field_category',
     'label' => 'Category',
-    'required' => 0,
+    'required' => 1,
     'settings' => array(
       'user_register_form' => FALSE,
     ),
@@ -499,7 +499,7 @@ function luggage_projects_field_default_field_instances() {
     'settings' => array(
       'description_field' => 0,
       'file_directory' => 'project/files',
-      'file_extensions' => 'pdf pptx ppt doc docx xlsx xls',
+      'file_extensions' => 'pdf xls xlsx doc docx rtf ppt pptx',
       'max_filesize' => '',
       'user_register_form' => FALSE,
     ),

--- a/luggage_projects.strongarm.inc
+++ b/luggage_projects.strongarm.inc
@@ -58,19 +58,19 @@ function luggage_projects_strongarm() {
     'extra_fields' => array(
       'form' => array(
         'metatags' => array(
-          'weight' => '14',
+          'weight' => '16',
         ),
         'title' => array(
           'weight' => '0',
         ),
         'path' => array(
-          'weight' => '13',
+          'weight' => '15',
         ),
         'redirect' => array(
           'weight' => '10',
         ),
         'xmlsitemap' => array(
-          'weight' => '12',
+          'weight' => '14',
         ),
       ),
       'display' => array(),


### PR DESCRIPTION
* Made category required
* Changed file extensions to be the same as other content types
* Moved metatag fields to bottom of field management administration pane

Some other changes weren't moved to this pull request because they were either resolved or not relevant.